### PR TITLE
Codex Skill: add prompt argument note

### DIFF
--- a/plugins/skill-codex/skills/codex/SKILL.md
+++ b/plugins/skill-codex/skills/codex/SKILL.md
@@ -15,6 +15,7 @@ description: Use when the user asks to run Codex CLI (codex exec, codex resume) 
    - `--full-auto`
    - `-C, --cd <DIR>`
    - `--skip-git-repo-check`
+   - `"your prompt here"` (as final positional argument)
 3. Always use --skip-git-repo-check.
 4. When continuing a previous session, use `codex exec --skip-git-repo-check resume --last` via stdin. When resuming don't use any configuration flags unless explicitly requested by the user e.g. if he species the model or the reasoning effort when requesting to resume a session. Resume syntax: `echo "your prompt here" | codex exec --skip-git-repo-check resume --last 2>/dev/null`. All flags have to be inserted between exec and resume.
 5. **IMPORTANT**: By default, append `2>/dev/null` to all `codex exec` commands to suppress thinking tokens (stderr). Only show stderr if the user explicitly requests to see thinking tokens or if debugging is needed.


### PR DESCRIPTION
## Summary

Clarifies that the prompt must be passed as a positional argument to `codex exec`, not via a `--prompt` flag.

## Background

During usage with **Claude Sonnet 4.5**, the skill documentation was unclear about how to pass the prompt argument. This led to Claude suggesting an incorrect syntax using a `--prompt` flag:

```bash
codex exec --skip-git-repo-check -m gpt-5.3-codex --config model_reasoning_effort="high" --sandbox read-only --prompt "Analyze..."
# Error: unexpected argument '--prompt' found
