### PR TITLE
Update model options in README and SKILL.md for Codex integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,12 +51,12 @@ Use codex to analyze this repository and suggest improvements for my claude code
 
 **Claude Code response:**
 Claude will activate the Codex skill and:
-1. Ask which model to use (`gpt-5.3-codex` or `gpt-5.2`) unless already specified in your prompt.
+1. Ask which model to use (`gpt-5.3-codex-spark`, `gpt-5.3-codex`, or `gpt-5.2`) unless already specified in your prompt.
 2. Ask which reasoning effort level (`low`, `medium`, or `high`) unless already specified in your prompt.
 3. Select appropriate sandbox mode (defaults to `read-only` for analysis)
 4. Run a command like:
 ```bash
-codex exec -m gpt-5.3-codex \
+codex exec -m gpt-5.3-codex-spark \
   --config model_reasoning_effort="high" \
   --sandbox read-only \
   --full-auto \

--- a/plugins/skill-codex/skills/codex/SKILL.md
+++ b/plugins/skill-codex/skills/codex/SKILL.md
@@ -6,7 +6,7 @@ description: Use when the user asks to run Codex CLI (codex exec, codex resume) 
 # Codex Skill Guide
 
 ## Running a Task
-1. Ask the user (via `AskUserQuestion`) which model to run (`gpt-5.3-codex` or `gpt-5.2`) AND which reasoning effort to use (`xhigh`, `high`, `medium`, or `low`) in a **single prompt with two questions**.
+1. Ask the user (via `AskUserQuestion`) which model to run (`gpt-5.3-codex-spark`, `gpt-5.3-codex`, or `gpt-5.2`) AND which reasoning effort to use (`xhigh`, `high`, `medium`, or `low`) in a **single prompt with two questions**.
 2. Select the sandbox mode required for the task; default to `--sandbox read-only` unless edits or network access are necessary.
 3. Assemble the command with the appropriate options:
    - `-m, --model <MODEL>`


### PR DESCRIPTION
## Summary                                                                  
Add gpt-5.3-codex-spark as a model option to the Codex skill plugin, updating both SKILL.md and README.md.

## Background                                                               

OpenAI released gpt-5.3-codex-spark, a new variant in the Codex model family. The skill previously only offered gpt-5.3-codex and gpt-5.2. This PR adds the new model so users can select it directly from the prompt.

## Changes
- plugins/skill-codex/skills/codex/SKILL.md — Added gpt-5.3-codex-spark to model selection list
- README.md — Updated example to include gpt-5.3-codex-spark and use it as default