### PR TITLE
Replace hardcoded model list with dynamic config discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,12 +51,12 @@ Use codex to analyze this repository and suggest improvements for my claude code
 
 **Claude Code response:**
 Claude will activate the Codex skill and:
-1. Ask which model to use (`gpt-5.3-codex-spark`, `gpt-5.3-codex`, or `gpt-5.2`) unless already specified in your prompt.
+1. Read `~/.codex/config.toml` to find the default model, and ask whether to use it or a different one (no hardcoded model list—any valid model string works).
 2. Ask which reasoning effort level (`low`, `medium`, or `high`) unless already specified in your prompt.
 3. Select appropriate sandbox mode (defaults to `read-only` for analysis)
 4. Run a command like:
 ```bash
-codex exec -m gpt-5.3-codex-spark \
+codex exec -m <MODEL> \
   --config model_reasoning_effort="high" \
   --sandbox read-only \
   --full-auto \

--- a/plugins/skill-codex/skills/codex/SKILL.md
+++ b/plugins/skill-codex/skills/codex/SKILL.md
@@ -6,7 +6,7 @@ description: Use when the user asks to run Codex CLI (codex exec, codex resume) 
 # Codex Skill Guide
 
 ## Running a Task
-1. Read `~/.codex/config.toml` to discover the user's default model (the `model` key). Ask the user (via `AskUserQuestion`) whether to use their default model or a different one, AND which reasoning effort to use (`xhigh`, `high`, `medium`, or `low`) in a **single prompt with two questions**. Do NOT hardcode model names—accept whatever model name the user provides, since `codex -m` accepts any valid model string.
+1. Read `~/.codex/config.toml` to discover the user's default model (the `model` key). **You MUST then use `AskUserQuestion`** to confirm the model (showing the default from config and allowing the user to specify a different one) AND which reasoning effort to use (`xhigh`, `high`, `medium`, or `low`) — **always ask both questions in a single prompt, even if defaults exist in the config. Never skip this step.** Do NOT hardcode model names—accept whatever model name the user provides, since `codex -m` accepts any valid model string.
 2. Select the sandbox mode required for the task; default to `--sandbox read-only` unless edits or network access are necessary.
 3. Assemble the command with the appropriate options:
    - `-m, --model <MODEL>`

--- a/plugins/skill-codex/skills/codex/SKILL.md
+++ b/plugins/skill-codex/skills/codex/SKILL.md
@@ -6,7 +6,7 @@ description: Use when the user asks to run Codex CLI (codex exec, codex resume) 
 # Codex Skill Guide
 
 ## Running a Task
-1. Ask the user (via `AskUserQuestion`) which model to run (`gpt-5.3-codex-spark`, `gpt-5.3-codex`, or `gpt-5.2`) AND which reasoning effort to use (`xhigh`, `high`, `medium`, or `low`) in a **single prompt with two questions**.
+1. Read `~/.codex/config.toml` to discover the user's default model (the `model` key). Ask the user (via `AskUserQuestion`) whether to use their default model or a different one, AND which reasoning effort to use (`xhigh`, `high`, `medium`, or `low`) in a **single prompt with two questions**. Do NOT hardcode model names—accept whatever model name the user provides, since `codex -m` accepts any valid model string.
 2. Select the sandbox mode required for the task; default to `--sandbox read-only` unless edits or network access are necessary.
 3. Assemble the command with the appropriate options:
    - `-m, --model <MODEL>`


### PR DESCRIPTION
## Summary

- **Removes hardcoded model names** (`gpt-5.3-codex-spark`, `gpt-5.3-codex`, `gpt-5.2`) from both `SKILL.md` and `README.md`
- **Reads `~/.codex/config.toml`** at runtime to discover the user's default model, then asks whether to use it or a different one
- **Accepts any valid model string** via `codex -m`, so new models work immediately without code changes

## Why

Every time OpenAI releases a new Codex model, a PR is needed just to update the hardcoded model list (see PRs #8 and #9 which only changed model names). This is unnecessary because:

1. The Codex CLI's `-m` flag accepts **any model string** — it's not restricted to a predefined set
2. Users already configure their preferred model in `~/.codex/config.toml` (the `model` key)
3. The skill can read that config at runtime and present it as the default, while still allowing the user to type any model name they want

With this change, no future PRs are needed when new models are added — the skill dynamically adapts to whatever models are available.

## What changed

| File | Change |
|------|--------|
| `SKILL.md` | Step 1 now reads `~/.codex/config.toml` for the default model instead of listing specific model names |
| `README.md` | Updated example workflow to match; command example uses `<MODEL>` placeholder |

## Test plan

- [x] Verified the skill reads `~/.codex/config.toml` and presents the configured default model
- [x] Verified users can type any arbitrary model name (e.g. `gpt-5.4`) and it is accepted
- [x] Verified the `codex exec -m <model>` command works with user-provided model strings

🤖 Generated with [Claude Code](https://claude.com/claude-code)