### PR TITLE
fix: bump version to 1.2.0 to reflect SKILL.md content changes

### DIFF
--- a/openpackage.yml
+++ b/openpackage.yml
@@ -1,5 +1,5 @@
 name: skill-codex
-version: 1.1.0
+version: 1.2.0
 description: Enable Claude Code to delegate tasks to OpenAI Codex CLI for code analysis, refactoring, and automated editing.
 author: skills-directory
 license: MIT

--- a/plugins/skill-codex/.claude-plugin/plugin.json
+++ b/plugins/skill-codex/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "skill-codex",
   "description": "Claude Code skill to delegate prompts to OpenAI Codex CLI for code analysis, refactoring, code review, and automated editing",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "author": {
     "name": "skills-directory",
     "url": "https://github.com/skills-directory"


### PR DESCRIPTION
## Summary
- Bump version in `plugin.json` and `openpackage.yml` from `1.1.0` to `1.2.0`
- PRs #8 and #10 updated SKILL.md (new model names, positional argument note) but didn't bump the version
- Users running `claude plugins update` can't receive the changes because Claude Code compares the installed version string against the marketplace version string — when both are `1.1.0`, it skips the update even though file contents differ

Fixes #15

## Files changed
- `plugins/skill-codex/.claude-plugin/plugin.json` — `"version": "1.1.0"` → `"version": "1.2.0"`
- `openpackage.yml` — `version: 1.1.0` → `version: 1.2.0`