### PR TITLE
docs: add toprank as related workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 Note: If you want a more autonomous setup for agentic workflows, check out [klaudworks/ralph-meets-rex](https://github.com/klaudworks/ralph-meets-rex).
 
+If you want a broader repo-aware Claude Code workflow for SEO, content, and Google Ads tasks, check out [nowork-studio/toprank](https://github.com/nowork-studio/toprank).
+
 # Codex Integration for Claude Code
 
 <img width="2288" height="808" alt="skillcodex" src="https://github.com/user-attachments/assets/85336a9f-4680-479e-b3fe-d6a68cadc051" />


### PR DESCRIPTION
Adds `nowork-studio/toprank` to the README as a related Claude Code workflow.

`toprank` is an open-source Claude Code plugin and skill set for SEO, Google Ads, content writing, and CMS optimization workflows.

## Credibility
`nowork-studio/toprank` currently has **126 GitHub stars**, 17 forks, and is MIT licensed.

## Why it fits
This repo already points readers at adjacent Claude Code workflow projects in the README. `toprank` is a complementary repo-aware workflow toolkit for users who want end-to-end marketing and content operations beyond direct Codex delegation.

Source: https://github.com/nowork-studio/toprank
