### PR TITLE
feat: add gpt-5.5 and gpt-5.4-mini models

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "skill-codex",
       "source": "./plugins/skill-codex",
       "description": "Delegate prompts to OpenAI Codex CLI for code analysis, refactoring, code review, and automated editing",
-      "version": "1.1.0",
+      "version": "1.3.0",
       "category": "development",
       "homepage": "https://github.com/skills-directory/skill-codex",
       "tags": [

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Use codex to analyze this repository and suggest improvements for my claude code
 
 **Claude Code response:**
 Claude will activate the Codex skill and:
-1. Ask which model to use (`gpt-5.4`, `gpt-5.3-codex-spark`, or `gpt-5.3-codex`) unless already specified in your prompt.
+1. Ask which model to use (`gpt-5.5`, `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.3-codex-spark`, or `gpt-5.3-codex`) unless already specified in your prompt.
 2. Ask which reasoning effort level (`low`, `medium`, or `high`) unless already specified in your prompt.
 3. Select appropriate sandbox mode (defaults to `read-only` for analysis)
 4. Run a command like:

--- a/openpackage.yml
+++ b/openpackage.yml
@@ -1,5 +1,5 @@
 name: skill-codex
-version: 1.2.0
+version: 1.3.0
 description: Enable Claude Code to delegate tasks to OpenAI Codex CLI for code analysis, refactoring, and automated editing.
 author: skills-directory
 license: MIT

--- a/plugins/skill-codex/.claude-plugin/plugin.json
+++ b/plugins/skill-codex/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "skill-codex",
   "description": "Claude Code skill to delegate prompts to OpenAI Codex CLI for code analysis, refactoring, code review, and automated editing",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "author": {
     "name": "skills-directory",
     "url": "https://github.com/skills-directory"

--- a/plugins/skill-codex/skills/codex/SKILL.md
+++ b/plugins/skill-codex/skills/codex/SKILL.md
@@ -6,7 +6,7 @@ description: Use when the user asks to run Codex CLI (codex exec, codex resume) 
 # Codex Skill Guide
 
 ## Running a Task
-1. Ask the user (via `AskUserQuestion`) which model to run (`gpt-5.4`, `gpt-5.3-codex-spark`, or `gpt-5.3-codex`) AND which reasoning effort to use (`xhigh`, `high`, `medium`, or `low`) in a **single prompt with two questions**.
+1. Ask the user (via `AskUserQuestion`) which model to run (`gpt-5.5`, `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.3-codex-spark`, or `gpt-5.3-codex`) AND which reasoning effort to use (`xhigh`, `high`, `medium`, or `low`) in a **single prompt with two questions**.
 2. Select the sandbox mode required for the task; default to `--sandbox read-only` unless edits or network access are necessary.
 3. Assemble the command with the appropriate options:
    - `-m, --model <MODEL>`


### PR DESCRIPTION
## Summary

OpenAI's Codex CLI now exposes two model slugs that aren't in the skill's hardcoded list:

- **`gpt-5.5`** — the new flagship coding model ([announcement](https://openai.com/index/introducing-gpt-5-5/)). My local `~/.codex/models_cache.json` lists it with `priority: 0` and a NUX message saying it's *"now available in Codex"*.
- **`gpt-5.4-mini`** — smaller/faster variant alongside `gpt-5.4`.

Without this PR, Claude doesn't offer either model when running the AskUserQuestion step, so users either pick a stale model or have to override `-m` manually.

## Changes

- `plugins/skill-codex/skills/codex/SKILL.md` — add the two slugs to the model list in step 1
- `README.md` — same, for the Example Workflow section
- Version bump **1.2.0 → 1.3.0** in `plugin.json`, `openpackage.yml`, **and** `.claude-plugin/marketplace.json` (the marketplace entry was still at 1.1.0 — see #15 — so this brings all three version fields in sync, ensuring `claude plugins update` actually delivers the change to installed users)

## Test plan

- [x] Verified `gpt-5.5` works against my local Codex install (`codex-cli 0.124.0`): `codex exec -m gpt-5.5 --skip-git-repo-check "say hi in 3 words"` returned a clean response
- [x] Confirmed both new slugs appear in `~/.codex/models_cache.json` with `visibility: "list"` and full `low/medium/high/xhigh` reasoning support
- [x] Diff is 5 files / 5 lines — minimal scope, no behavioural changes beyond the model list

## Notes

Following the same pattern as #9 (which added gpt-5.4). I'm separately opening an issue to discuss whether this recurring "add-the-new-model" PR cycle could be replaced with runtime discovery from `~/.codex/models_cache.json` — explicitly **not** proposing it here since #11 was closed on cost grounds, and I want to revisit the framing first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)