### PR TITLE
Document codex exec stdin-blocking pitfall, fix step numbering

### DIFF
--- a/plugins/skill-codex/skills/codex/SKILL.md
+++ b/plugins/skill-codex/skills/codex/SKILL.md
@@ -16,11 +16,11 @@ description: Use when the user asks to run Codex CLI (codex exec, codex resume) 
    - `-C, --cd <DIR>`
    - `--skip-git-repo-check`
    - `"your prompt here"` (as final positional argument)
-3. Always use --skip-git-repo-check.
-4. When continuing a previous session, use `codex exec --skip-git-repo-check resume --last` via stdin. When resuming don't use any configuration flags unless explicitly requested by the user e.g. if he species the model or the reasoning effort when requesting to resume a session. Resume syntax: `echo "your prompt here" | codex exec --skip-git-repo-check resume --last 2>/dev/null`. All flags have to be inserted between exec and resume.
-5. **IMPORTANT**: By default, append `2>/dev/null` to all `codex exec` commands to suppress thinking tokens (stderr). Only show stderr if the user explicitly requests to see thinking tokens or if debugging is needed.
-6. Run the command, capture stdout/stderr (filtered as appropriate), and summarize the outcome for the user.
-7. **After Codex completes**, inform the user: "You can resume this Codex session at any time by saying 'codex resume' or asking me to continue with additional analysis or changes."
+4. Always use --skip-git-repo-check.
+5. When continuing a previous session, use `codex exec --skip-git-repo-check resume --last` via stdin. When resuming don't use any configuration flags unless explicitly requested by the user e.g. if he species the model or the reasoning effort when requesting to resume a session. Resume syntax: `echo "your prompt here" | codex exec --skip-git-repo-check resume --last 2>/dev/null`. All flags have to be inserted between exec and resume.
+6. **IMPORTANT**: By default, append `2>/dev/null` to all `codex exec` commands to suppress thinking tokens (stderr). Only show stderr if the user explicitly requests to see thinking tokens or if debugging is needed.
+7. Run the command, capture stdout/stderr (filtered as appropriate), and summarize the outcome for the user.
+8. **After Codex completes**, inform the user: "You can resume this Codex session at any time by saying 'codex resume' or asking me to continue with additional analysis or changes."
 
 ### Quick Reference
 | Use case | Sandbox mode | Key flags |

--- a/plugins/skill-codex/skills/codex/SKILL.md
+++ b/plugins/skill-codex/skills/codex/SKILL.md
@@ -19,8 +19,9 @@ description: Use when the user asks to run Codex CLI (codex exec, codex resume) 
 4. Always use --skip-git-repo-check.
 5. When continuing a previous session, use `codex exec --skip-git-repo-check resume --last` via stdin. When resuming don't use any configuration flags unless explicitly requested by the user e.g. if he species the model or the reasoning effort when requesting to resume a session. Resume syntax: `echo "your prompt here" | codex exec --skip-git-repo-check resume --last 2>/dev/null`. All flags have to be inserted between exec and resume.
 6. **IMPORTANT**: By default, append `2>/dev/null` to all `codex exec` commands to suppress thinking tokens (stderr). Only show stderr if the user explicitly requests to see thinking tokens or if debugging is needed.
-7. Run the command, capture stdout/stderr (filtered as appropriate), and summarize the outcome for the user.
-8. **After Codex completes**, inform the user: "You can resume this Codex session at any time by saying 'codex resume' or asking me to continue with additional analysis or changes."
+7. **IMPORTANT (stdin)**: `codex exec` always reads stdin and concatenates it with the positional prompt -- even when the prompt is fully supplied as a positional argument. If stdin is not closed, codex blocks forever. When invoking from a harness (background tasks, hooks, scripts where stdin is not a TTY but also not closed), explicitly redirect stdin: append `</dev/null` to the command, e.g. `codex exec ... "prompt" </dev/null 2>/dev/null`. Symptom of getting this wrong: zero bytes of stdout, zero CPU accumulated, process appears hung indefinitely.
+8. Run the command, capture stdout/stderr (filtered as appropriate), and summarize the outcome for the user.
+9. **After Codex completes**, inform the user: "You can resume this Codex session at any time by saying 'codex resume' or asking me to continue with additional analysis or changes."
 
 ### Quick Reference
 | Use case | Sandbox mode | Key flags |


### PR DESCRIPTION
## Summary

Two small docs-only commits to `plugins/skill-codex/skills/codex/SKILL.md`:

1. **Fix duplicate step numbering in Running a Task** -- the list had two steps numbered `3` (the multi-line "Assemble the command" step and "Always use --skip-git-repo-check"). Renumbered so the list is sequential.
2. **Document codex exec stdin-blocking pitfall** -- adds an IMPORTANT note describing a failure mode that hangs `codex exec` indefinitely when invoked from a harness.

## The stdin pitfall

`codex exec` always reads stdin and concatenates whatever it reads with the positional prompt -- even when the prompt is fully supplied as a positional argument. If stdin is not closed, codex blocks forever waiting for EOF.

This bites when invoking from background tasks, hooks, or CI scripts where stdin is not a TTY but also is not closed (it inherits from the parent). Symptom: zero bytes of stdout, zero CPU accumulated, process appears hung indefinitely.

Fix: append `</dev/null` to the command, e.g. `codex exec ... "prompt" </dev/null 2>/dev/null`.

Discovered while running a backgrounded `codex exec` for an automated review -- it sat at 0 bytes / 0 CPU for several minutes before I killed and re-ran with the redirect. Worth a line in the skill so the next person does not hit it.

## Test plan

- [x] Renders cleanly in the existing numbered list; the new step slots in between the existing `2>/dev/null` note and "Run the command".
- [x] No code/behavior changes -- docs only.