### PR TITLE
Add auth pre-flight check and align docs

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "skill-codex",
       "source": "./plugins/skill-codex",
       "description": "Delegate prompts to OpenAI Codex CLI for code analysis, refactoring, code review, and automated editing",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "category": "development",
       "homepage": "https://github.com/skills-directory/skill-codex",
       "tags": [

--- a/README.md
+++ b/README.md
@@ -52,14 +52,13 @@ Use codex to analyze this repository and suggest improvements for my claude code
 **Claude Code response:**
 Claude will activate the Codex skill and:
 1. Ask which model to use (`gpt-5.5`, `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.3-codex-spark`, or `gpt-5.3-codex`) unless already specified in your prompt.
-2. Ask which reasoning effort level (`low`, `medium`, or `high`) unless already specified in your prompt.
+2. Ask which reasoning effort level (`xhigh`, `high`, `medium`, or `low`) unless already specified in your prompt.
 3. Select appropriate sandbox mode (defaults to `read-only` for analysis)
 4. Run a command like:
 ```bash
 codex exec -m gpt-5.3-codex-spark \
   --config model_reasoning_effort="high" \
   --sandbox read-only \
-  --full-auto \
   --skip-git-repo-check \
   "Analyze this Claude Code skill repository comprehensively..." 2>/dev/null
 ```

--- a/openpackage.yml
+++ b/openpackage.yml
@@ -1,5 +1,5 @@
 name: skill-codex
-version: 1.3.0
+version: 1.4.0
 description: Enable Claude Code to delegate tasks to OpenAI Codex CLI for code analysis, refactoring, and automated editing.
 author: skills-directory
 license: MIT

--- a/plugins/skill-codex/.claude-plugin/plugin.json
+++ b/plugins/skill-codex/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "skill-codex",
   "description": "Claude Code skill to delegate prompts to OpenAI Codex CLI for code analysis, refactoring, code review, and automated editing",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "author": {
     "name": "skills-directory",
     "url": "https://github.com/skills-directory"

--- a/plugins/skill-codex/skills/codex/SKILL.md
+++ b/plugins/skill-codex/skills/codex/SKILL.md
@@ -5,6 +5,24 @@ description: Use when the user asks to run Codex CLI (codex exec, codex resume) 
 
 # Codex Skill Guide
 
+## Pre-flight (before every run)
+
+Before the first `codex exec`, confirm the CLI is present and authenticated. This turns an otherwise cryptic mid-run failure into one clear, actionable message:
+
+```bash
+command -v codex >/dev/null 2>&1 || { echo "ERROR: codex not found in PATH"; exit 1; }
+codex --version
+if codex login status >/dev/null 2>&1; then
+  echo "Auth: signed in with ChatGPT"
+elif [ -n "$OPENAI_API_KEY" ]; then
+  echo "Auth: OPENAI_API_KEY is set"
+else
+  echo "ERROR: Codex is not authenticated"; exit 1
+fi
+```
+
+If neither auth source is present, stop and tell the user to run `codex login` (Sign in with ChatGPT) or export an API key (`export OPENAI_API_KEY=sk-...`). Do not start a `codex exec` run until this check passes.
+
 ## Running a Task
 1. Ask the user (via `AskUserQuestion`) which model to run (`gpt-5.5`, `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.3-codex-spark`, or `gpt-5.3-codex`) AND which reasoning effort to use (`xhigh`, `high`, `medium`, or `low`) in a **single prompt with two questions**.
 2. Select the sandbox mode required for the task; default to `--sandbox read-only` unless edits or network access are necessary.


### PR DESCRIPTION
## What

Two small, focused improvements to the codex skill:

1. **Auth pre-flight** (`feat`) — a new "Pre-flight (before every run)" section in `SKILL.md` that verifies the `codex` binary is on `PATH` and that the CLI is authenticated (`codex login status` succeeds, or `OPENAI_API_KEY` is set) before the first `codex exec`. Fails fast with an actionable message instead of a cryptic mid-run error.
2. **Doc fixes** (`docs`) — align the README reasoning-effort list with `SKILL.md`/the CLI (`xhigh, high, medium, low`), and drop `--full-auto` from the read-only analysis example (an edit-oriented auto-approval flag that is misleading next to `--sandbox read-only`).

Version bumped `1.3.0` → `1.4.0` across `plugin.json`, `marketplace.json`, and `openpackage.yml`.

## Why

The skill previously ran `codex exec` with no auth verification, so an unauthenticated or misconfigured CLI failed deep in the run with an error that was hard to attribute. The README also listed an incomplete effort set and a read-only example that passed an edit-approval flag.

## Testing

- Ran the pre-flight snippet against `codex-cli 0.142.4`: prints the version and `Auth: signed in with ChatGPT` (exit 0) — confirms `codex login status` is a valid, scriptable auth check on the current CLI.
- `bash -n` on the snippet: syntax valid; `jq` validates both JSON manifests after the version bump.
- Reviewed the diff with two independent models; the one actionable point (avoid printing a key prefix / non-POSIX substring) was incorporated — the API-key branch now prints `Auth: OPENAI_API_KEY is set`.
