### PR TITLE
Add optional prompt templates for common Codex tasks

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "skill-codex",
       "source": "./plugins/skill-codex",
       "description": "Delegate prompts to OpenAI Codex CLI for code analysis, refactoring, code review, and automated editing",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "category": "development",
       "homepage": "https://github.com/skills-directory/skill-codex",
       "tags": [

--- a/openpackage.yml
+++ b/openpackage.yml
@@ -1,5 +1,5 @@
 name: skill-codex
-version: 1.3.0
+version: 1.4.0
 description: Enable Claude Code to delegate tasks to OpenAI Codex CLI for code analysis, refactoring, and automated editing.
 author: skills-directory
 license: MIT

--- a/plugins/skill-codex/.claude-plugin/plugin.json
+++ b/plugins/skill-codex/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "skill-codex",
   "description": "Claude Code skill to delegate prompts to OpenAI Codex CLI for code analysis, refactoring, code review, and automated editing",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "author": {
     "name": "skills-directory",
     "url": "https://github.com/skills-directory"

--- a/plugins/skill-codex/skills/codex/SKILL.md
+++ b/plugins/skill-codex/skills/codex/SKILL.md
@@ -23,6 +23,26 @@ description: Use when the user asks to run Codex CLI (codex exec, codex resume) 
 8. Run the command, capture stdout/stderr (filtered as appropriate), and summarize the outcome for the user.
 9. **After Codex completes**, inform the user: "You can resume this Codex session at any time by saying 'codex resume' or asking me to continue with additional analysis or changes."
 
+## Prompt templates (optional)
+
+For common tasks you can build the prompt from a ready-made template instead of writing it freeform. Templates live in [`templates/`](templates/) next to this file; each holds a prompt skeleton with `<placeholders>` and a built-in rigorous-colleague stance (findings first, severity-ordered, cite `file:line`, push back, flag uncertainty).
+
+Selection is inference-first and never blocks the user:
+
+- If the request clearly matches a type (or names one), read the matching `templates/<name>.md` and fill its skeleton with the concrete scope/goal.
+- Otherwise, treat the user's request as the freeform prompt (the current default). Do **not** ask a separate question just to pick a template.
+
+| Type | File | Use when the user wants... |
+|------|------|----------------------------|
+| Code Review | `templates/code-review.md` | a review / second opinion / quality check |
+| Refactoring | `templates/refactor.md` | to refactor, clean up, or restructure |
+| Security Audit | `templates/security-audit.md` | a security / vulnerability audit |
+| Bug Hunt | `templates/bug-hunt.md` | to root-cause a specific bug or failure |
+| Test Gen | `templates/test-gen.md` | tests added or a coverage/gap analysis |
+| General | `templates/general.md` | a structured prompt when no specific template fits (opt-in; unmatched requests otherwise stay freeform) |
+
+Templates only shape the prompt text passed to `codex exec`. Model, reasoning effort, sandbox mode, stderr handling, and resume behavior stay governed by the rest of this guide.
+
 ### Quick Reference
 | Use case | Sandbox mode | Key flags |
 | --- | --- | --- |

--- a/plugins/skill-codex/skills/codex/templates/bug-hunt.md
+++ b/plugins/skill-codex/skills/codex/templates/bug-hunt.md
@@ -1,0 +1,11 @@
+# Template: Bug Hunt
+
+Use to root-cause a specific bug or failure.
+
+Prompt skeleton (fill the `<placeholders>` and pass as the `codex exec` prompt):
+
+> Investigate `<symptom>` in `<scope>`. Form explicit hypotheses, inspect the
+> relevant code paths, and identify the most likely root cause with evidence
+> (`file:line`). Propose the smallest correct fix and list concrete steps to
+> verify it. If you cannot confirm the cause, say what additional information or
+> reproduction would be needed rather than guessing.

--- a/plugins/skill-codex/skills/codex/templates/code-review.md
+++ b/plugins/skill-codex/skills/codex/templates/code-review.md
@@ -1,0 +1,12 @@
+# Template: Code Review
+
+Use when the user asks to review code, wants a second opinion, or a quality check.
+
+Prompt skeleton (fill the `<placeholders>` and pass as the `codex exec` prompt):
+
+> Act as a rigorous senior reviewer of `<scope>`. Review for correctness,
+> regressions, maintainability, and missing tests. Report findings first, ordered
+> by severity (critical → low), each with a `file:line` reference and a concrete
+> fix. Challenge unclear intent and risky patterns and push back where the design
+> seems wrong. Do not invent issues — cite evidence, and say so plainly if the
+> code looks fine.

--- a/plugins/skill-codex/skills/codex/templates/general.md
+++ b/plugins/skill-codex/skills/codex/templates/general.md
@@ -1,0 +1,10 @@
+# Template: General
+
+Use only when the user wants a structured prompt but no specific template fits.
+It is not the default — unmatched requests should normally stay freeform.
+
+Prompt skeleton (fill the `<placeholders>` and pass as the `codex exec` prompt):
+
+> `<the user's task, in full>`. Work in `<scope>`. Be precise, cite file paths and
+> line numbers for anything you reference, and explain non-obvious decisions.
+> Flag assumptions and anything you are uncertain about instead of guessing.

--- a/plugins/skill-codex/skills/codex/templates/refactor.md
+++ b/plugins/skill-codex/skills/codex/templates/refactor.md
@@ -1,0 +1,10 @@
+# Template: Refactoring
+
+Use when the user wants refactoring suggestions or a restructure.
+
+Prompt skeleton (fill the `<placeholders>` and pass as the `codex exec` prompt):
+
+> Refactor `<scope>` to achieve `<goal, e.g. readability, performance, simplicity,
+> testability>` while preserving observable behavior. Keep changes minimal and follow the
+> existing patterns in the codebase. Explain the trade-offs and why the new shape
+> is better, and list the tests that should be run to confirm behavior is unchanged.

--- a/plugins/skill-codex/skills/codex/templates/security-audit.md
+++ b/plugins/skill-codex/skills/codex/templates/security-audit.md
@@ -1,0 +1,12 @@
+# Template: Security Audit
+
+Use for security-focused review (vulnerabilities, insecure defaults, secrets).
+
+Prompt skeleton (fill the `<placeholders>` and pass as the `codex exec` prompt):
+
+> Perform a security audit of `<scope>`, focusing on `<threat focus, e.g. injection,
+> auth, secrets, deserialization, SSRF, supply chain, insecure defaults>`. Report
+> findings first, ordered by severity (critical → low). Prioritize exploitable risks
+> over theoretical ones, cite concrete evidence (`file:line`) for each finding, and
+> propose a specific mitigation. Avoid speculative findings and state your confidence
+> for each.

--- a/plugins/skill-codex/skills/codex/templates/test-gen.md
+++ b/plugins/skill-codex/skills/codex/templates/test-gen.md
@@ -1,0 +1,11 @@
+# Template: Test Generation / Gap Analysis
+
+Use to add tests or assess coverage.
+
+Prompt skeleton (fill the `<placeholders>` and pass as the `codex exec` prompt):
+
+> Assess test coverage for `<scope>` and generate focused, high-quality tests.
+> Cover edge cases, error paths, and invariants, and follow the project's existing
+> test framework and style. Prioritize high-risk untested behavior and cite it with
+> `file:line`; avoid broad, unrelated testing advice. List which behaviors remain
+> untested after your additions.


### PR DESCRIPTION
## What

Adds an **optional prompt-template** system so Claude can build consistent, high-quality Codex prompts for common tasks instead of ad-hoc freeform ones.

- A new `## Prompt templates (optional)` router in `SKILL.md` maps task types to skeletons and selects by **inference** — it never blocks the user; unmatched requests stay freeform (the current default).
- Six templates under `plugins/skill-codex/skills/codex/templates/`: `code-review`, `refactor`, `security-audit`, `bug-hunt`, `test-gen`, `general`. Each embeds the skill's rigorous-colleague stance (findings-first, severity-ordered, cite `file:line`, push back, flag uncertainty).
- Templates only shape the prompt text — model, reasoning effort, sandbox mode, stderr handling, and resume behaviour are unchanged.

Version bumped `1.4.0` → `1.5.0`.

## Why

Prompt quality and structure varied per invocation, and the review ethos had to be re-stated each time. Templates make the common cases consistent while keeping the skill's flexibility.

## Notes

- Bundled as load-on-demand files (progressive disclosure), so `SKILL.md` only pays a small always-loaded routing cost.
- Selection is inference-first and skippable by design (no extra question added).
